### PR TITLE
add support for multiline titleLabels

### DIFF
--- a/DLRadioButton/DLRadioButton.m
+++ b/DLRadioButton/DLRadioButton.m
@@ -22,7 +22,9 @@ static BOOL _groupModifing = NO;
     }
     _otherButtons = otherButtons;
 }
-
+-(CGSize)intrinsicContentSize {
+	return CGSizeMake(super.intrinsicContentSize.width , self.titleLabel.intrinsicContentSize.height);
+}
 - (void)setIcon:(UIImage *)icon {
     _icon = icon;
     [self setImage:self.icon forState:UIControlStateNormal];
@@ -260,6 +262,12 @@ static BOOL _groupModifing = NO;
 - (void)drawRect:(CGRect)rect {
     [super drawRect:rect];
     [self drawButton];
+}
+
+- (void)layoutSubviews
+{
+	[super layoutSubviews];
+	self.titleLabel.preferredMaxLayoutWidth = self.titleLabel.frame.size.width;
 }
 
 @end


### PR DESCRIPTION
UIButtons doesn't automatically support multiline labels, but having subclassed it we have the opportunity to fix it!
(related to https://github.com/DavydLiu/DLRadioButton/issues/58)
